### PR TITLE
modify README/pom.xml to align with the dependency story

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,7 +114,7 @@ Since it's unlikely that you'll want to distribute or work with _.class_ files d
 mvn package
 ----
 
-The _package_ goal will compile your Java code, run any tests, and finish by packaging the code up in a JAR file within the _target_ directory. The name of the JAR file will be based on the project's `<artifactId>` and `<version>`. For example, given the minimal _pom.xml_ file from before, the JAR file will be named _{project_id}-initial-0.1.0.jar_.
+The _package_ goal will compile your Java code, run any tests, and finish by packaging the code up in a JAR file within the _target_ directory. The name of the JAR file will be based on the project's `<artifactId>` and `<version>`. For example, given the minimal _pom.xml_ file from before, the JAR file will be named _{project_id}-0.1.0.jar_.
 
 NOTE: If you've changed the value of `<packaging>` from "jar" to "war", the result will be a WAR file within the _target_ directory instead of a JAR file.
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -7,16 +7,6 @@
     <packaging>jar</packaging>
     <version>0.1.0</version>
 
-    <!-- tag::joda[] -->
-    <dependencies>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.2</version>
-        </dependency>
-    </dependencies>
-    <!-- end::joda[] -->
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
- Remove joda-time dependency from initial/pom.xml to aligh with the story: "If you were to run mvn compile to build the project now, the build would fail because you’ve not declared Joda Time as a compile dependency in the build."
- (a tiny fix) the result JAR file should be "{project_id}-0.1.0.jar" rather than "{project_id}-initial-0.1.0.jar"
