### PR TITLE
Fixed format of the link to semver.org (Obvious Fix)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ With the exception of the optional `<packaging>` element, this is the simplest p
 * `<version>`. Version of the project that is being built.
 * `<packaging>` - How the project should be packaged. Defaults to "jar" for JAR file packaging. Use "war" for WAR file packaging.
 
-NOTE: When it comes to choosing a versioning scheme, Spring recommends the [semantic versioning](http://semver.org) approach.
+NOTE: When it comes to choosing a versioning scheme, Spring recommends the http://semver.org[semantic versioning] approach.
 
 At this point you have a minimal, yet capable Maven project defined.
 


### PR DESCRIPTION
I'm correcting the link to http://semver.org to use the right [AsciiDoc](http://asciidoc.org/) format. The correct format is given in section 21.1.1 of the [AsciiDoc user guide](http://asciidoc.org/asciidoc.css-embedded.html).

Before the correction:
![screen shot 2017-12-31 at 3 36 33 pm](https://user-images.githubusercontent.com/5433410/34464125-07715118-ee41-11e7-9529-3d9a52cd3208.png)

![screen shot 2017-12-31 at 3 37 23 pm](https://user-images.githubusercontent.com/5433410/34464126-0a823912-ee41-11e7-8300-581261ee81d3.png)

After:
![screen shot 2017-12-31 at 3 39 23 pm](https://user-images.githubusercontent.com/5433410/34464128-13705b80-ee41-11e7-81b5-d6aeaad4d9f7.png)
