### PR TITLE
Update version of shade plugin

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.1</version>
+				<version>3.2.4</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -18,7 +18,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
for me, in case of using version 2.1 , when run "mvn package", the following problem "java.io.FileNotFoundException: /home/guoxiang/.m2/repository/org/apache/maven/maven-project/2.2.0/maven-project-2.2.0.jar.lastUpdated (Permission denied)" happened, using the version 3.2.4 will help to avoid this problem.